### PR TITLE
Add annotations to the output file

### DIFF
--- a/src/mpidiff/MPIDiff.cpp
+++ b/src/mpidiff/MPIDiff.cpp
@@ -261,6 +261,28 @@ bool MPIDiff::Initialized() {
 ///
 /// @author Alan Dayton
 ///
+/// @brief Add annotation to the MPIDiff output file.
+///
+/// This is useful for providing context as to where diffs first appear.
+/// For example, if a function is called repeatedly you could add a
+/// static counter to the function and use that to annotate the MPIDiff
+/// output file. Then you know exactly which call to the function first
+/// produced diffs.
+///
+/// @arg[in]  annotation  String to write to the MPIDiff output file
+///
+/////////////////////////////////////////////////////////////////////////
+void MPIDiff::Annotate(const std::string& annotation) {
+   if (Get_debug_rank() < Get_partner_debug_rank()) {
+      std::ofstream& s_outputFile = Get_output_file();
+      s_outputFile << annotation << "\n";
+   }
+}
+
+/////////////////////////////////////////////////////////////////////////
+///
+/// @author Alan Dayton
+///
 /// @brief Set message handler.
 ///
 /// @arg[in] handler Function to call when message tags match

--- a/src/mpidiff/MPIDiff.h
+++ b/src/mpidiff/MPIDiff.h
@@ -93,6 +93,23 @@ class MPIDiff {
       ///
       /// @author Alan Dayton
       ///
+      /// @brief Add annotation to the MPIDiff output file.
+      ///
+      /// This is useful for providing context as to where diffs first appear.
+      /// For example, if a function is called repeatedly you could add a
+      /// static counter to the function and use that to annotate the MPIDiff
+      /// output file. Then you know exactly which call to the function first
+      /// produced diffs.
+      ///
+      /// @arg[in]  annotation  String to write to the MPIDiff output file
+      ///
+      /////////////////////////////////////////////////////////////////////////
+      static void Annotate(const std::string& annotation);
+
+      /////////////////////////////////////////////////////////////////////////
+      ///
+      /// @author Alan Dayton
+      ///
       /// @brief Set message handler.
       ///
       /// @arg[in] handler Function to call when message tags match


### PR DESCRIPTION
Add MPIDiff::Annotate function for adding context to the MPIDiff output file.