### PR TITLE
Standalone build improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tpl/blt"]
+	path = tpl/blt
+	url = https://github.com/LLNL/blt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.14)
 ##########################################################################
 
 project(MPIDiff
-        LANGUAGES CXX
+        LANGUAGES C CXX
         VERSION 0.1.10)
 
 include(${PROJECT_SOURCE_DIR}/cmake/Setup.cmake)

--- a/cmake/SetupBLTWrapper.cmake
+++ b/cmake/SetupBLTWrapper.cmake
@@ -6,16 +6,52 @@
 ######################################################################################
 
 if(NOT BLT_LOADED)
-   if(DEFINED BLT_SOURCE_DIR)
-      if(EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
-         include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
-      else()
+   if(BLT_SOURCE_DIR)
+      message(STATUS "MPIDiff: Using external BLT")
+
+      if(NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
          message(FATAL_ERROR
-                "Given BLT_SOURCE_DIR does not contain SetupBLT.cmake!")
+                 "MPIDiff: Given BLT_SOURCE_DIR does not contain SetupBLT.cmake")
       endif()
    else()
-      message(FATAL_ERROR
-              "BLT is required!"
-              "Add -DBLT_SOURCE_DIR=/path/to/blt to your CMake command.")
+      message(STATUS "MPIDiff: Using BLT submodule")
+
+      set(BLT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/tpl/blt")
+
+      if(NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
+         message(FATAL_ERROR "MPIDiff: BLT submodule is not initialized. Run `git submodule update --init` in git repository or set BLT_SOURCE_DIR to external BLT.")
+      endif()
    endif()
+
+   include(CMakeDependentOption)
+
+   option(ENABLE_BENCHMARKS "Enables benchmarks" OFF)
+   option(ENABLE_DOCS       "Enables documentation" OFF)
+   option(ENABLE_EXAMPLES   "Enables examples" OFF)
+   option(ENABLE_TESTS      "Enables tests" ON)
+
+   option(ENABLE_GIT "Enables Git support" OFF)
+
+   cmake_dependent_option(ENABLE_DOXYGEN "Enables Doxygen support"
+                          ON "ENABLE_DOCS" OFF)
+
+   cmake_dependent_option(ENABLE_SPHINX "Enables Sphinx support"
+                          ON "ENABLE_DOCS" OFF)
+
+   option(ENABLE_CLANGQUERY "Enables clang-query support" OFF)
+   option(ENABLE_CLANGTIDY  "Enables clang-tidy support" OFF)
+   option(ENABLE_CPPCHECK   "Enables Cppcheck support" OFF)
+   option(ENABLE_VALGRIND   "Enables Valgrind support" OFF)
+
+   option(ENABLE_ASTYLE      "Enables AStyle support" OFF)
+   option(ENABLE_CLANGFORMAT "Enables ClangFormat support" OFF)
+   option(ENABLE_UNCRUSTIFY  "Enables Uncrustify support" OFF)
+   option(ENABLE_YAPF        "Enables Yapf support" OFF)
+   option(ENABLE_CMAKEFORMAT "Enables CMakeFormat support" OFF)
+
+   option(ENABLE_FORTRAN "Enables Fortran compiler support" OFF)
+
+   set(BLT_CXX_STD "c++14" CACHE STRING "Set the c++ standard to use")
+
+   include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 endif()

--- a/cmake/SetupOptions.cmake
+++ b/cmake/SetupOptions.cmake
@@ -7,10 +7,12 @@
 
 include(CMakeDependentOption)
 
-cmake_dependent_option(MPIDIFF_ENABLE_TESTS "Build tests" ON "ENABLE_TESTS" OFF)
-cmake_dependent_option(MPIDIFF_ENABLE_DOCS "Build documentation" ON "ENABLE_DOCS" OFF)
-cmake_dependent_option(MPIDIFF_ENABLE_EXAMPLES "Build examples" ON "ENABLE_EXAMPLES" OFF)
+set(ENABLE_MPI ON CACHE BOOL "")
 
 if(NOT ENABLE_MPI)
    message(FATAL_ERROR "MPIDiff requires ENABLE_MPI.")
 endif()
+
+cmake_dependent_option(MPIDIFF_ENABLE_TESTS "Build tests" ON "ENABLE_TESTS" OFF)
+cmake_dependent_option(MPIDIFF_ENABLE_DOCS "Build documentation" ON "ENABLE_DOCS" OFF)
+cmake_dependent_option(MPIDIFF_ENABLE_EXAMPLES "Build examples" ON "ENABLE_EXAMPLES" OFF)

--- a/host-configs/lc/blueos_3_ppc64le_ib_p9/nvcc_clang.cmake
+++ b/host-configs/lc/blueos_3_ppc64le_ib_p9/nvcc_clang.cmake
@@ -5,20 +5,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
+# Set up software versions
 set(CLANG_VERSION "ibm-14.0.5" CACHE PATH "")
 set(CUDA_VERSION "11.8.0" CACHE PATH "")
 set(GCC_VERSION "11.2.1" CACHE PATH "")
 
+# Set up compilers
 set(COMPILER_BASE "/usr/tce/packages/clang/clang-${CLANG_VERSION}" CACHE PATH "")
 set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/clang" CACHE PATH "")
 set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/clang++" CACHE PATH "")
 
+# Set up compiler flags
 set(GCC_HOME "/usr/tce/packages/gcc/gcc-${GCC_VERSION}" CACHE PATH "")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 
+# Prevent the wrong libraries from being linked in
 set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/lib64" CACHE STRING "")
 
+# Set up CUDA
 set(ENABLE_CUDA ON CACHE BOOL "Enable CUDA")
 set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-${CUDA_VERSION}" CACHE PATH "Path to CUDA")
 set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
@@ -26,6 +31,7 @@ set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE PATH "")
 set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=--gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 
+# Set up MPI
 set(ENABLE_MPI ON CACHE BOOL "")
 set(MPI_BASE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-${CLANG_VERSION}" CACHE PATH "")
 set(MPI_C_COMPILER "${MPI_BASE}/bin/mpiclang" CACHE PATH "")

--- a/host-configs/lc/blueos_3_ppc64le_ib_p9/nvcc_clang.cmake
+++ b/host-configs/lc/blueos_3_ppc64le_ib_p9/nvcc_clang.cmake
@@ -1,0 +1,28 @@
+##############################################################################
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC and MPIDiff
+# project contributors. See the MPIDiff LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
+set(COMPILER_BASE "/usr/tce/packages/clang/clang-ibm-14.0.5" CACHE PATH "")
+set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/clang" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/clang++" CACHE PATH "")
+
+set(GCC_HOME "/usr/tce/packages/gcc/gcc-11.2.1" CACHE PATH "")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/lib64" CACHE STRING "")
+
+set(ENABLE_CUDA ON CACHE BOOL "Enable CUDA")
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-11.8.0" CACHE PATH "Path to CUDA")
+set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
+set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE PATH "")
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=--gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+set(MPI_BASE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-ibm-14.0.5" CACHE PATH "")
+set(MPI_C_COMPILER "${MPI_BASE}/bin/mpiclang" CACHE PATH "")
+set(MPI_CXX_COMPILER "${MPI_BASE}/bin/mpiclang++" CACHE PATH "")

--- a/host-configs/lc/blueos_3_ppc64le_ib_p9/nvcc_clang.cmake
+++ b/host-configs/lc/blueos_3_ppc64le_ib_p9/nvcc_clang.cmake
@@ -5,24 +5,28 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
-set(COMPILER_BASE "/usr/tce/packages/clang/clang-ibm-14.0.5" CACHE PATH "")
+set(CLANG_VERSION "ibm-14.0.5" CACHE PATH "")
+set(CUDA_VERSION "11.8.0" CACHE PATH "")
+set(GCC_VERSION "11.2.1" CACHE PATH "")
+
+set(COMPILER_BASE "/usr/tce/packages/clang/clang-${CLANG_VERSION}" CACHE PATH "")
 set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/clang" CACHE PATH "")
 set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/clang++" CACHE PATH "")
 
-set(GCC_HOME "/usr/tce/packages/gcc/gcc-11.2.1" CACHE PATH "")
+set(GCC_HOME "/usr/tce/packages/gcc/gcc-${GCC_VERSION}" CACHE PATH "")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 
 set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/lib64" CACHE STRING "")
 
 set(ENABLE_CUDA ON CACHE BOOL "Enable CUDA")
-set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-11.8.0" CACHE PATH "Path to CUDA")
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-${CUDA_VERSION}" CACHE PATH "Path to CUDA")
 set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
 set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE PATH "")
 set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=--gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 
 set(ENABLE_MPI ON CACHE BOOL "")
-set(MPI_BASE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-ibm-14.0.5" CACHE PATH "")
+set(MPI_BASE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-${CLANG_VERSION}" CACHE PATH "")
 set(MPI_C_COMPILER "${MPI_BASE}/bin/mpiclang" CACHE PATH "")
 set(MPI_CXX_COMPILER "${MPI_BASE}/bin/mpiclang++" CACHE PATH "")

--- a/host-configs/lc/toss_4_x86_64_ib/clang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/clang.cmake
@@ -5,16 +5,23 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
-set(COMPILER_BASE "/usr/tce/packages/clang/clang-14.0.6-magic" CACHE PATH "")
+# Set up software versions
+set(CLANG_VERSION "14.0.6" CACHE PATH "")
+set(MVAPICH2_VERSION "2.3.7" CACHE PATH "")
+set(GCC_VERSION "12.1.1" CACHE PATH "")
+
+# Set up compilers
+set(COMPILER_BASE "/usr/tce/packages/clang/clang-${CLANG_VERSION}-magic" CACHE PATH "")
 set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/clang" CACHE PATH "")
 set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/clang++" CACHE PATH "")
 
-set(GCC_HOME "/usr/tce/packages/gcc/gcc-12.1.1-magic" CACHE PATH "")
+# Set up compiler flags
+set(GCC_HOME "/usr/tce/packages/gcc/gcc-${GCC_VERSION}-magic" CACHE PATH "")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 
+# Set up MPI
 set(ENABLE_MPI ON CACHE BOOL "")
-
-set(MPI_BASE "/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6-magic" CACHE PATH "")
+set(MPI_BASE "/usr/tce/packages/mvapich2/mvapich2-${MVAPICH2_VERSION}-clang-${CLANG_VERSION}-magic" CACHE PATH "")
 set(MPI_C_COMPILER "${MPI_BASE}/bin/mpicc" CACHE PATH "")
 set(MPI_CXX_COMPILER "${MPI_BASE}/bin/mpicxx" CACHE PATH "")

--- a/host-configs/lc/toss_4_x86_64_ib/clang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/clang.cmake
@@ -1,0 +1,20 @@
+##############################################################################
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC and MPIDiff
+# project contributors. See the MPIDiff LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
+set(COMPILER_BASE "/usr/tce/packages/clang/clang-14.0.6-magic" CACHE PATH "")
+set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/clang" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/clang++" CACHE PATH "")
+
+set(GCC_HOME "/usr/tce/packages/gcc/gcc-12.1.1-magic" CACHE PATH "")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_BASE "/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6-magic" CACHE PATH "")
+set(MPI_C_COMPILER "${MPI_BASE}/bin/mpicc" CACHE PATH "")
+set(MPI_CXX_COMPILER "${MPI_BASE}/bin/mpicxx" CACHE PATH "")

--- a/host-configs/lc/toss_4_x86_64_ib/intel.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/intel.cmake
@@ -5,16 +5,23 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
-set(COMPILER_BASE "/usr/tce/packages/intel/intel-2022.1.0-magic" CACHE PATH "")
+# Set up software versions
+set(INTEL_VERSION "2022.1.0" CACHE PATH "")
+set(MVAPICH2_VERSION "2.3.7" CACHE PATH "")
+set(GCC_VERSION "12.1.1" CACHE PATH "")
+
+# Set up compilers
+set(COMPILER_BASE "/usr/tce/packages/intel/intel-${INTEL_VERSION}-magic" CACHE PATH "")
 set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/icx" CACHE PATH "")
 set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/icpx" CACHE PATH "")
 
-set(GCC_HOME "/usr/tce/packages/gcc/gcc-12.1.1-magic" CACHE PATH "")
+# Set up compiler flags
+set(GCC_HOME "/usr/tce/packages/gcc/gcc-${GCC_VERSION}-magic" CACHE PATH "")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
 
+# Set up MPI
 set(ENABLE_MPI ON CACHE BOOL "")
-
-set(MPI_BASE "/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0-magic" CACHE PATH "")
+set(MPI_BASE "/usr/tce/packages/mvapich2/mvapich2-${MVAPICH2_VERSION}-intel-${INTEL_VERSION}-magic" CACHE PATH "")
 set(MPI_C_COMPILER "${MPI_BASE}/bin/mpicc" CACHE PATH "")
 set(MPI_CXX_COMPILER "${MPI_BASE}/bin/mpicxx" CACHE PATH "")

--- a/host-configs/lc/toss_4_x86_64_ib/intel.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/intel.cmake
@@ -1,0 +1,20 @@
+##############################################################################
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC and MPIDiff
+# project contributors. See the MPIDiff LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
+set(COMPILER_BASE "/usr/tce/packages/intel/intel-2022.1.0-magic" CACHE PATH "")
+set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/icx" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/icpx" CACHE PATH "")
+
+set(GCC_HOME "/usr/tce/packages/gcc/gcc-12.1.1-magic" CACHE PATH "")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_BASE "/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2022.1.0-magic" CACHE PATH "")
+set(MPI_C_COMPILER "${MPI_BASE}/bin/mpicc" CACHE PATH "")
+set(MPI_CXX_COMPILER "${MPI_BASE}/bin/mpicxx" CACHE PATH "")

--- a/host-configs/lc/toss_4_x86_64_ib_cray/amdclang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib_cray/amdclang.cmake
@@ -1,0 +1,33 @@
+##############################################################################
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC and MPIDiff
+# project contributors. See the MPIDiff LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
+# Set up software versions
+set(ROCM_VERSION "6.2.0" CACHE PATH "")
+set(MPICH_VERSION "8.1.30" CACHE PATH "")
+set(GCC_VERSION "12.2.1" CACHE PATH "")
+
+# Set up compilers
+set(COMPILER_BASE "/usr/tce/packages/rocmcc/rocmcc-${ROCM_VERSION}-magic" CACHE PATH "")
+set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/amdclang" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/amdclang++" CACHE PATH "")
+
+# Set up compiler flags
+set(GCC_HOME "/usr/tce/packages/gcc/gcc-${GCC_VERSION}" CACHE PATH "")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_HOME}" CACHE STRING "")
+
+# Set up HIP
+set(ENABLE_HIP ON CACHE BOOL "")
+set(ROCM_PATH "/usr/tce/packages/rocmcc/rocmcc-${ROCM_VERSION}-magic" CACHE PATH "")
+set(CMAKE_HIP_ARCHITECTURES "gfx942" CACHE STRING "")
+set(AMDGPU_TARGETS "${CMAKE_HIP_ARCHITECTURES}" CACHE STRING "")
+
+# Set up MPI
+set(ENABLE_MPI ON CACHE BOOL "")
+set(MPI_BASE "/usr/tce/packages/cray-mpich-tce/cray-mpich-${MPICH_VERSION}-rocmcc-${ROCM_VERSION}" CACHE PATH "")
+set(MPI_C_COMPILER "${MPI_BASE}/bin/mpiamdclang"   CACHE PATH "")
+set(MPI_CXX_COMPILER "${MPI_BASE}/bin/mpiamdclang++" CACHE PATH "")

--- a/src/mpidiff/MPIDiff.cpp
+++ b/src/mpidiff/MPIDiff.cpp
@@ -32,7 +32,6 @@ static int m_debugRank;
 
 static int m_multiProgramNumRanks;
 static int m_programNumRanks;
-static int m_debugNumRanks;
 
 static int m_partnerMultiProgramRank;
 static int m_partnerProgramRank;
@@ -140,7 +139,7 @@ void MPIDiff::Init(const MPI_Comm multiProgramCommunicator, int programID) {
                                  m_multiProgramCommunicator));
 
    // Make a list of ranks with my program ID
-   int m_programNumRanks = 0;
+   m_programNumRanks = 0;
    int* ranksWithMyProgramID = (int*) allocateMemory(m_multiProgramNumRanks * sizeof(int));
 
    bool multiplePrograms = false;

--- a/src/mpidiff/MPIDiff.h
+++ b/src/mpidiff/MPIDiff.h
@@ -698,7 +698,7 @@ class MPIDiff {
       /////////////////////////////////////////////////////////////////////////
       template <class T, class BinaryPredicate, class TToString>
       static void Default_diff(int program1ID, int size1, const T* data1,
-                               int program2ID, int size2, const T* data2,
+                               int program2ID, int /* size2 */, const T* data2,
                                std::string key, BinaryPredicate predicate,
                                TToString toString) {
          std::ofstream& s_outputFile = Get_output_file();


### PR DESCRIPTION
* Add BLT as a submodule (but still allow an external BLT to be specified)
* Add host config files for some platforms
* Fix some build warnings about unused variables
* Enable MPI by default since it is required