### PR TITLE
Make diffs a quiet no-op if MPIDiff is not initialized

### DIFF
--- a/src/mpidiff/MPIDiff.h
+++ b/src/mpidiff/MPIDiff.h
@@ -231,7 +231,6 @@ class MPIDiff {
                        BinaryPredicate predicate, TToString toString) {
          // Check that we are in a valid state
          if (!Initialized()) {
-            std::cerr << "[MPIDiff] MPIDiff::Init must be called before MPIDiff::Diff. Unable to perform diffs!" << std::endl;
             return;
          }
 
@@ -332,7 +331,6 @@ class MPIDiff {
                              BinaryPredicate predicate, TToString toString) {
          // Check that we are in a valid state
          if (!Initialized()) {
-            std::cerr << "[MPIDiff] MPIDiff::Init must be called before MPIDiff::Diff. Unable to perform diffs!" << std::endl;
             return;
          }
 


### PR DESCRIPTION
* This output prevents one application's tests from passing and the benefit of the warning is minimal anyway 